### PR TITLE
Typo fix: Remove a duplicated ')'

### DIFF
--- a/docs/WatchPlugins.md
+++ b/docs/WatchPlugins.md
@@ -49,7 +49,7 @@ Below are the hooks available in Jest.
 
 #### `jestHooks.shouldRunTestSuite(testPath)`
 
-Returns a boolean (or `Promise<boolean>`) for handling asynchronous operations) to specify if a test should be run or not.
+Returns a boolean (or `Promise<boolean>` for handling asynchronous operations) to specify if a test should be run or not.
 
 For example:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Just a typo fix: Remove a duplicated ')' on Documentation of WatchPlugin.

## Test plan

No test.
